### PR TITLE
feat: introduce cover override functionality and UI enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.1.0] - 2025-08-12
+
+### Added
+
+- Auto cover:
+  - now lets you override the cover applied to a roll in the roll dialog
+  - now lets you set keybind that if held will let you override cover for the roll (for people that dont use roll dialog, you maniacs)
+
 ## [2.0.1] - 2025-08-12
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -34,11 +34,18 @@ Support: [https://ko-fi.com/roileaf](https://ko-fi.com/roileaf)
 - States: Observed, Concealed, Hidden, Undetected.
 - State data lives in token flags; it’s robust across reloads and scenes.
 
-### Visibility Manager UI
+### Per‑Observer Cover States
+
+- Cover is tracked for each attacker→target pair.
+- States: None, Lesser (+1), Standard (+2), Greater (+4).
+- Cover data is stored per pair and only applied to mechanics at roll time (see Auto Cover below).
+
+### Token Manager UI (Visibility & Cover)
 
 - Modern ApplicationV2 UI with responsive layout and fixed controls.
 - Color-coded rows, hover to highlight tokens on the canvas, sortable table.
 - “Apply All” and “Revert All” flows with per‑row apply/revert.
+- Cover and visibility tabs use consistent iconography and colors.
 
 ### Visual Feedback
 
@@ -99,6 +106,44 @@ Visioner augments PF2e chat cards with buttons that open result dialogs and appl
 
 ---
 
+## 🛡️ Auto Cover & Roll Overrides
+
+When enabled, Visioner evaluates cover between the acting token and its current target and applies the appropriate bonus to the target’s AC for that roll only.
+
+### How it works
+
+- On attack/spell-attack rolls, Visioner computes cover just-in-time and injects a one‑shot effect to the target so the DC/AC reflects the chosen cover.
+- After the roll’s chat message renders, Visioner cleans up any one‑shot cover effect.
+- If a token moves during an active attack flow, Visioner clears any previously applied cover; re‑evaluation happens at the moment of rolling.
+
+### Modifiers dialog (with dialog open)
+
+- GMs see a “Visioner Cover Override” row with four icon buttons: None, Lesser, Standard, Greater.
+- The auto-calculated state is highlighted; click another icon to override for that roll.
+- Uses Visioner’s shield icons and colors throughout the module.
+
+### Quick rolls (no dialog)
+
+- Bind a key in Controls to: “Hold to Override Cover on Quick Rolls” (no default binding).
+- Hold that key while clicking a strike to open a compact override window (AppV2) with the same four icons and a Roll button.
+- Pick a cover; Visioner applies it for that roll and then cleans up automatically.
+
+### Auto‑Cover options (world settings)
+
+- Enable Auto‑Cover: master toggle.
+- Token Intersection Mode: how token blockers count (Center, ≥10%, ≥20%).
+- Ignore Undetected Blockers: attackers ignore blockers they can’t detect per Visioner visibility map.
+- Ignore Dead Tokens: skip 0‑HP blockers.
+- Ignore Allies: skip same‑alliance blockers.
+- Respect Token Ignore Flag: tokens with `flags.pf2e-visioner.ignoreAutoCover = true` won’t provide cover.
+- Prone Tokens Can Block: when off, prone tokens are skipped as blockers.
+
+Notes:
+- Auto‑Cover is GM‑only to avoid duplicates.
+- Cover application is transient; Visioner stores the computed state for UI consistency but only adjusts mechanics during the roll.
+
+---
+
 ## 🧠 Off‑Guard Automation
 
 - Applies off‑guard where appropriate based on Hidden/Undetected relationships.
@@ -119,6 +164,9 @@ Visioner augments PF2e chat cards with buttons that open result dialogs and appl
 - Seek Range Value / Out of Combat (world): range distances (ft).
 - Use Token HUD Button (world): adds a quick access button on token HUD.
 - Block Target Tooltips for Players (world): disable “target‑perspective” tooltips for players.
+- Auto‑Cover (world): enable Visioner’s cover evaluation and roll‑time application.
+- Auto‑Cover: Token Intersection Mode (world): Center / ≥10% / ≥20%.
+- Auto‑Cover: Ignore Undetected / Ignore Dead / Ignore Allies / Respect Token Ignore Flag / Prone Tokens Can Block.
 - Debug (world): verbose logging for troubleshooting.
 
 ---
@@ -127,6 +175,7 @@ Visioner augments PF2e chat cards with buttons that open result dialogs and appl
 
 - Open Visibility Manager: Ctrl+Shift+V
 - Toggle Observer Mode for Hover Tooltips: O (hold to switch to observer mode; release to return to target mode)
+- Hold to Override Cover on Quick Rolls: unbound by default; configure in Controls. Hold while clicking a strike to open the quick cover override window.
 
 ---
 
@@ -141,6 +190,9 @@ await api?.openVisibilityManager(token);
 - setVisibility(observerId, targetId, state)
 - updateTokenVisuals(token?)
 - getVisibilityStates()
+- getCoverBetween(observerId, targetId)
+- setCoverBetween(observerId, targetId, state)
+- getCoverStates()
 
 See `scripts/api.js` for the current surface.
 
@@ -179,6 +231,10 @@ Visioner ships a `PF2eVisionerVisibility` rule element for item‑driven visibil
 - Seek Template flow with GM gate, player template handoff, and “no targets → no button”.
 - Point Out flow rework with robust target resolution and single‑ping rule.
 - UI polish: scrollbars, scaling, initiative‑aware ephemeral durations.
+- Auto‑Cover with roll‑time application and instant cleanup.
+- Modifiers dialog cover override row with icon buttons.
+- Quick‑override mini dialog (AppV2) triggered by a configurable hold key.
+- Movement clears pre‑applied cover; re‑evaluation happens on roll.
 
 ---
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -261,7 +261,9 @@
       }
     },
     "UI": {
-      "ENCOUNTER_FILTER_TEXT": "Show only encounter tokens"
+      "ENCOUNTER_FILTER_TEXT": "Show only encounter tokens",
+      "COVER_OVERRIDE": "Visioner Cover Override",
+      "ROLL": "Roll"
     },
     "WALL": {
       "VISIBLE_TO_YOU": "Hidden Wall"
@@ -274,6 +276,10 @@
       "OPEN_VISIBILITY_MANAGER": {
         "name": "Open Token Visibility Manager",
         "hint": "Open the visibility manager for selected tokens"
+      },
+      "HOLD_COVER_OVERRIDE": {
+        "name": "Hold to Override Cover on Quick Rolls",
+        "hint": "When held while clicking a strike/attack (no dialog), use Visioner cover override instead of auto-calculated cover. No default; configure your own key."
       },
       "TOGGLE_OBSERVER_MODE": {
         "name": "Toggle Observer Mode for Hover Tooltips",

--- a/module.json
+++ b/module.json
@@ -9,7 +9,7 @@
       "flags": {}
     }
   ],
-  "version": "2.0.1",
+  "version": "2.1.0",
   "compatibility": {
     "minimum": "13.341",
     "verified": "13.346"

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -364,4 +364,10 @@ export const KEYBINDINGS = {
     hint: "PF2E_VISIONER.KEYBINDINGS.TOGGLE_OBSERVER_MODE.hint",
     editable: [{ key: "KeyO", modifiers: [] }],
   },
+  holdCoverOverride: {
+    name: "PF2E_VISIONER.KEYBINDINGS.HOLD_COVER_OVERRIDE.name",
+    hint: "PF2E_VISIONER.KEYBINDINGS.HOLD_COVER_OVERRIDE.hint",
+    // No default binding; user can configure
+    editable: [],
+  },
 };

--- a/scripts/cover/quick-override-dialog.js
+++ b/scripts/cover/quick-override-dialog.js
@@ -1,0 +1,118 @@
+import { COVER_STATES, MODULE_ID } from "../constants.js";
+import { getCoverBonusByState, getCoverLabel } from "../helpers/cover-helpers.js";
+
+let currentCoverQuickDialog = null;
+
+export class CoverQuickOverrideDialog extends foundry.applications.api.ApplicationV2 {
+  static DEFAULT_OPTIONS = {
+    id: "pv-cover-quick-override",
+    tag: "div",
+    window: {
+      title: "Visioner Cover Override",
+      icon: "fas fa-shield-alt",
+      resizable: false,
+    },
+    position: { width: 380, height: "auto" },
+    classes: [MODULE_ID, "pv-cover-quick-override"],
+    actions: {
+      roll: CoverQuickOverrideDialog._onRoll,
+      cancel: CoverQuickOverrideDialog._onCancel,
+    },
+  };
+
+  constructor(initialState = "none", options = {}) {
+    super(options);
+    this.selected = initialState;
+    this._resolver = null;
+    currentCoverQuickDialog = this;
+  }
+
+  setResolver(fn) { this._resolver = fn; }
+
+  _getStates() { return ["none", "lesser", "standard", "greater"]; }
+
+  async _renderHTML(_context, _options) {
+    const states = this._getStates();
+    const makeButton = (s) => {
+      const cfg = COVER_STATES?.[s] || {}; const icon = cfg.icon || "fas fa-shield-alt"; const color = cfg.color || "inherit"; const label = getCoverLabel(s); const bonus = getCoverBonusByState(s) || 0;
+      const tooltip = `${label}${bonus > 0 ? ` (+${bonus})` : ''}`;
+      const active = s === this.selected;
+      return `<button type="button" class="pv-qo-btn${active ? ' active' : ''}" data-state="${s}" title="${tooltip}" data-tooltip="${tooltip}" aria-label="${tooltip}">
+          <i class="${icon}" style="color:${color}"></i>
+      </button>`;
+    };
+    const rollLabel = game.i18n?.localize?.("PF2E_VISIONER.UI.ROLL") ?? game.i18n?.localize?.("PF2E.Roll") ?? "Roll";
+    const cancelLabel = game.i18n?.localize?.("Cancel") ?? "Cancel";
+    return `
+      <style>
+        .pv-qo-wrap { display:flex; flex-direction:column; gap:8px; }
+        .pv-qo-row { display:flex; justify-content:center; gap:8px; }
+        .pv-qo-btn { width:32px; height:32px; border:1px solid rgba(255,255,255,0.2); border-radius:6px; background:transparent; display:inline-flex; align-items:center; justify-content:center; cursor:pointer; }
+        .pv-qo-btn.active { background: var(--color-bg-tertiary, rgba(0,0,0,0.2)); }
+        .pv-qo-title { font-weight:600; text-align:center; }
+        .pv-qo-footer { display:flex; justify-content:center; gap:8px; margin-top:8px; }
+        .pv-qo-footer .roll { background: var(--color-primary-2, #2c5aa0); color: #fff; }
+      </style>
+      <div class="pv-qo-wrap">
+        <div class="pv-qo-row">${states.map(makeButton).join("")}</div>
+        <div class="pv-qo-footer">
+          <button type="button" class="roll" data-action="roll"><i class="fas fa-dice-d20"></i> ${rollLabel}</button>
+          <button type="button" data-action="cancel">${cancelLabel}</button>
+        </div>
+      </div>
+    `;
+  }
+
+  _replaceHTML(result, content, _options) {
+    content.innerHTML = result;
+    return content;
+  }
+
+  _onRender(context, options) {
+    super._onRender?.(context, options);
+    // Attach selection handlers
+    try {
+      const root = this.element;
+      root.querySelectorAll(".pv-qo-btn").forEach((btn) => {
+        btn.addEventListener("click", (ev) => {
+          const el = ev.currentTarget; const s = el?.dataset?.state; if (!s) return;
+          this.selected = s;
+          root.querySelectorAll(".pv-qo-btn").forEach((b) => b.classList.remove("active"));
+          el.classList.add("active");
+        });
+      });
+    } catch (_) { /* ignore */ }
+  }
+
+  static _onRoll(event, button) {
+    const app = currentCoverQuickDialog; if (!app) return;
+    try { app._resolver?.(app.selected); } catch (_) {}
+    app.close();
+  }
+
+  static _onCancel(event, button) {
+    const app = currentCoverQuickDialog; if (!app) return;
+    try { app._resolver?.(null); } catch (_) {}
+    app.close();
+  }
+
+  close(options) {
+    currentCoverQuickDialog = null;
+    return super.close(options);
+  }
+}
+
+/**
+ * Opens the ApplicationV2-based dialog and resolves with selection or null.
+ */
+export function openCoverQuickOverrideDialog(initialState = "none") {
+  return new Promise((resolve) => {
+    try {
+      const app = new CoverQuickOverrideDialog(initialState);
+      app.setResolver(resolve);
+      app.render(true);
+    } catch (e) { resolve(null); }
+  });
+}
+
+


### PR DESCRIPTION
- Added a new feature allowing users to override cover settings during rolls, including a keybind for quick access.
- Implemented a quick override dialog for selecting cover states, enhancing user experience.
- Updated the CHANGELOG to reflect the new version 2.1.0 and document the added functionalities.
- Enhanced auto-cover mechanics to support the new override feature, ensuring seamless integration with existing roll processes.