### PR TITLE
Game setting for default token manager mode when opened with keybind

### DIFF
--- a/scripts/api.js
+++ b/scripts/api.js
@@ -45,8 +45,9 @@ export class Pf2eVisionerApi {
   /**
    * Open the token manager for a specific observer token
    * @param {Token} observer - The observer token (optional, uses controlled tokens if not provided)
+   * @param options - data to pass to the token manager constructor. mode can be 'observer' or 'target'
    */
-  static async openTokenManager(observer = null) {
+  static async openTokenManager(observer = null, options = {mode: "observer"}) {
     if (!game.user.isGM) {
       ui.notifications.warn("Only GMs can manage token visibility and cover");
       return;
@@ -100,7 +101,7 @@ export class Pf2eVisionerApi {
       return VisionerTokenManager.currentInstance;
     }
 
-    const manager = new VisionerTokenManager(observer);
+    const manager = new VisionerTokenManager(observer, {mode: options.mode});
     await manager.render({ force: true });
     try {
       if (manager.element || manager.window) manager.bringToFront();

--- a/scripts/config/settings.js
+++ b/scripts/config/settings.js
@@ -60,6 +60,9 @@ export function registerSettings() {
       } else if (key === "customSeekDistanceOutOfCombat") {
         // No reload needed: seek distance is read at runtime
         settingConfig.onChange = () => {};
+      } else if (key === "keybindingOpensTMInTargetMode") {
+        // No reload needed: seek distance is read at runtime
+        settingConfig.onChange = () => {};
       } else if (key === "blockPlayerTargetTooltips") {
         // No reload: will take effect on next hover; ensure initialized when allowed
         settingConfig.onChange = async () => {
@@ -129,8 +132,9 @@ export function registerKeybindings() {
     // Add appropriate handler
     if (key === "openTokenManager") {
       keybindingConfig.onDown = async () => {
+        const mode = game.settings.get(MODULE_ID, "keybindingOpensTMInTargetMode") ? "target" : "observer";
         const { api } = await import("../api.js");
-        await api.openTokenManager();
+        await api.openTokenManager(null, {mode});
       };
     } else if (key === "openVisibilityManager") {
       keybindingConfig.onDown = async () => {

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -364,6 +364,14 @@ export const DEFAULT_SETTINGS = {
     type: Boolean,
     default: true,
   },
+  keybindingOpensTMInTargetMode: {
+    name: "Keybinding Opens Token Manager in Target Mode",
+    hint: "If enabled, the keybinding to open Token Manager in Target mode rather than Observer mode.",
+    scope: "world",
+    config: true,
+    type: Boolean,
+    default: false,
+  },
 
   debug: {
     name: "Debug Mode",

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -27,6 +27,7 @@ const SETTINGS_GROUPS = {
     "useHudButton",
     "integrateRollOutcome",
     "enforceRawRequirements",
+    "keybindingOpensTMInTargetMode",
     "sneakRawEnforcement",
   ],
   "Seek & Range": [
@@ -371,6 +372,9 @@ export function registerSettings() {
             document.body.classList.add(`pf2e-visioner-colorblind-${value}`);
           }
         };
+      } else if (key === "keybindingOpensTMInTargetMode") {
+        // No reload needed: swap mode is read at runtime
+        settingConfig.onChange = () => {};
       }
 
       try {
@@ -406,8 +410,9 @@ export function registerKeybindings() {
     // Add appropriate handler
     if (key === "openTokenManager") {
       keybindingConfig.onDown = async () => {
+        const mode = game.settings.get(MODULE_ID, "keybindingOpensTMInTargetMode") ? "target" : "observer";
         const { api } = await import("./api.js");
-        await api.openTokenManager();
+        await api.openTokenManager(null, {mode});
       };
     } else if (key === "openVisibilityManager") {
       keybindingConfig.onDown = async () => {


### PR DESCRIPTION
This adds a game setting so token manager can open in target mode from the keybind. Pretty trivial change, but I did have to add a new parameter to openTokenManager so that I could specify the opening mode.

Not sure why there are two settings.js files but I did the change in both. Has been working fine for me for two days.