### PR TITLE
Set data-tooltip attribute on token HUD

### DIFF
--- a/scripts/services/token-hud.js
+++ b/scripts/services/token-hud.js
@@ -65,7 +65,7 @@ function renderVisibilityButton(app, html) {
   buttonElement.className = 'control-icon';
   buttonElement.style.display = 'flex';
   buttonElement.setAttribute('data-action', 'pf2e-visioner-visibility');
-  buttonElement.title = 'Visibility Manager (Left: Target Mode | Right: Observer Mode)';
+  buttonElement.setAttribute('data-tooltip', 'Visibility Manager (Left: Target Mode | Right: Observer Mode)');
   buttonElement.innerHTML = '<i class="fas fa-face-hand-peeking"></i>';
 
   // Add click handlers for both left and right click


### PR DESCRIPTION
Changes the visibility manager token tool tooltip to use data-tooltip instead of title, which will give it the proper css classes for a tooltip.