### PR TITLE
Fix target radius, use cross product instead of distance

### DIFF
--- a/scripts/visibility/auto-visibility/LightingCalculator.js
+++ b/scripts/visibility/auto-visibility/LightingCalculator.js
@@ -94,7 +94,7 @@ export class LightingCalculator {
 
     // Convert the shape to clipper points
     const tokenClipperPoints = shapeInWorld.toClipperPoints({ scalingFactor: 1.0 });
-    const tokenRadius = (token?.externalRadius ?? Math.max(tokenWidth, tokenHeight)) / 2;
+    const tokenRadius = token?.externalRadius ?? (Math.max(tokenWidth, tokenHeight) / 2);
 
     // First process all non-hidden darkness sources since they override illumination
     let maxDarknessResult = null;


### PR DESCRIPTION
- External radius was being inadvertently cut in half
- Spent good thinking time last night planning how to use cross product to pick tangent point, then stupidly coded a distance check instead this morning. Cross product identifies proper side of target away from light, distance doesn't.