### PR TITLE
fix hide showing on save throws

### DIFF
--- a/scripts/chat/services/action-extractor.js
+++ b/scripts/chat/services/action-extractor.js
@@ -63,7 +63,8 @@ export async function extractActionData(message) {
       (context.options?.includes('action:hide') || context.slug === 'hide')) ||
       (message.flavor?.toLowerCase?.().includes?.('hide') &&
         !message.flavor?.toLowerCase?.().includes?.('create a diversion') &&
-        !message.flavor?.toLowerCase?.().includes?.('sneak attack'))) &&
+        !message.flavor?.toLowerCase?.().includes?.('sneak attack') &&
+        !message.flavor?.toLowerCase?.().includes?.('Saving Throw'))) &&
     !message.flavor?.toLowerCase?.().includes?.('sneak');
 
   const isAttackRoll =

--- a/scripts/chat/services/action-extractor.js
+++ b/scripts/chat/services/action-extractor.js
@@ -64,7 +64,7 @@ export async function extractActionData(message) {
       (message.flavor?.toLowerCase?.().includes?.('hide') &&
         !message.flavor?.toLowerCase?.().includes?.('create a diversion') &&
         !message.flavor?.toLowerCase?.().includes?.('sneak attack') &&
-        !message.flavor?.toLowerCase?.().includes?.('Saving Throw'))) &&
+        !message.flavor?.toLowerCase?.().includes?.('saving throw'))) &&
     !message.flavor?.toLowerCase?.().includes?.('sneak');
 
   const isAttackRoll =


### PR DESCRIPTION
Fixes #131 
Could not get an exact replication but this is where the data is located and adding this will exclude all saving throws. 