### PR TITLE
Use token vision LOS if available

### DIFF
--- a/scripts/visibility/StatelessVisibilityCalculator.js
+++ b/scripts/visibility/StatelessVisibilityCalculator.js
@@ -51,7 +51,7 @@ export function calculateVisibility(input) {
     const observer = normalizeObserverState(input.observer);
     const rayDarkness = input.rayDarkness || null;
     const soundBlocked = input.soundBlocked ?? false;
-    const hasLineOfSight = input.hasLineOfSight ?? true; // Default to true (fail open)
+    const hasLineOfSight = input.hasLineOfSight ?? undefined; // Default to undefined (ie unknown)
     const isInvisible = target.auxiliary.includes('invisible');
 
     // Decision tree: follow PF2e visibility rules in priority order
@@ -392,7 +392,7 @@ function checkPreciseNonVisualSenses(observer, target, soundBlocked = false) {
 /**
  * Determine if observer can detect target visually based on lighting and vision capabilities
  */
-function determineVisualDetection(observer, target, rayDarkness = null, hasLineOfSight = true) {
+function determineVisualDetection(observer, target, rayDarkness = null, hasLineOfSight = undefined) {
     // CRITICAL: Blinded observers cannot use any visual senses
     if (observer.conditions.blinded) {
         return {
@@ -404,7 +404,7 @@ function determineVisualDetection(observer, target, rayDarkness = null, hasLineO
     }
 
     // CRITICAL: If there's no line of sight (sight-blocking wall), visual detection fails
-    if (!hasLineOfSight) {
+    if (hasLineOfSight === false) {
         return {
             canDetect: false,
             sense: null,

--- a/scripts/visibility/VisibilityCalculatorAdapter.js
+++ b/scripts/visibility/VisibilityCalculatorAdapter.js
@@ -78,7 +78,7 @@ export async function tokenStateToInput(
         );
 
     // Allow skipping LOS check via options (useful for diagnostic APIs)
-    const hasLineOfSight = options?.skipLOS ? true : visionAnalyzer.hasLineOfSight(observer, target);
+    const hasLineOfSight = options?.skipLOS ? undefined : visionAnalyzer.hasLineOfSight(observer, target);
     const soundBlocked = visionAnalyzer.isSoundBlocked(observer, target);
 
 

--- a/scripts/visibility/auto-visibility/VisionAnalyzer.js
+++ b/scripts/visibility/auto-visibility/VisionAnalyzer.js
@@ -187,7 +187,7 @@ export class VisionAnalyzer {
       // If the observer has an los shape, use that for line of sight against the target's circle
       // Darkness sources may affect true LOS, so only return true/false if we can be sure
       const los = observer.vision?.los;
-      if (!!los?.points) {
+      if (los?.points) {
         const radius = target.externalRadius;
         const circle = new PIXI.Circle(target.center.x, target.center.y, radius);
         const intersection = los.intersectCircle(circle, {density: 8, scalingFactor: 1.0});

--- a/scripts/visibility/auto-visibility/VisionAnalyzer.js
+++ b/scripts/visibility/auto-visibility/VisionAnalyzer.js
@@ -184,10 +184,21 @@ export class VisionAnalyzer {
    */
   hasLineOfSight(observer, target) {
     try {
+      // If the observer has an los shape, use that for line of sight against the target's circle
+      // Darkness sources may affect true LOS, so only return true/false if we can be sure
+      const los = observer.vision?.los;
+      if (!!los?.points) {
+        const radius = target.externalRadius;
+        const circle = new PIXI.Circle(target.center.x, target.center.y, radius);
+        const intersection = los.intersectCircle(circle, {density: 8, scalingFactor: 1.0});
+        const visible = intersection?.points?.length > 0;
+        if (visible || !canvas.effects?.darknessSources?.length) return visible;
+      }
+
       // Check if LOS calculation is disabled
       const losDisabled = game.settings.get(MODULE_ID, 'disableLineOfSightCalculation');
       if (losDisabled) {
-        return true; // Always allow LOS when disabled
+        return undefined; // return undefined if LOS calculation is disabled
       }
 
       const ray = new foundry.canvas.geometry.Ray(observer.center, target.center);


### PR DESCRIPTION
Uses the token vision los shape for the test if available. If darkness sources are present, it will drop out to doing ray casting only if the target token wasn't deemed visible to the observer's vision los.